### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "chartist": "^0.11.2",
     "d3": "^5.9.2",
     "http-server": "^0.11.1",
-    "npm": "^6.9.0",
     "raphael": "^2.2.8",
     "taucharts": "^2.7.3",
     "tui-chart": "^3.7.0",


### PR DESCRIPTION

Hello DJN1!

It seems like you have npm as one of your (dev-) dependency in graphLibComp.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
